### PR TITLE
docs: add Claude Desktop configuration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,30 @@ Run `npx mcp-shell`. The server will start and listen for MCP commands via stand
 
 Start (or restart) [Claude Desktop](https://claude.ai/download) and you should see the MCP tool listed on the landing page.
 
+### Configuration with Claude Desktop
+
+To integrate with Claude Desktop, add the following configuration to your `claude_desktop_config.json` (typically located at `~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
+
+```json
+{
+  "mcpServers": {
+    "shell": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-shell"
+      ]
+    }
+  }
+}
+```
+
+After adding the configuration:
+1. Save the config file
+2. Restart Claude Desktop
+3. You should see a warning message about module loading - this is normal and won't affect functionality
+4. The shell commands will be available to Claude
+
 ## Security Features
 
 The server implements several security measures:


### PR DESCRIPTION
This PR adds detailed configuration instructions for integrating mcp-shell with Claude Desktop.

Changes:
- Added a new section "Configuration with Claude Desktop" under Installation
- Included example configuration for `claude_desktop_config.json`
- Added steps for configuration and expected behavior
- Mentioned the normal warning message about module loading

The configuration has been tested and works as expected.