### PR TITLE
src: add 'config' cmd, `--debug` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ A Node.js implementation of the Model Context Protocol (MCP) that provides secur
 
 ## Installation
 
-Run `npx mcp-shell` and it'll add itself to Claude Desktop's config.
+Run `npx mcp-shell`.
+
+To add it to Claude Desktop, run `npx mcp-shell config`. Or add `npx -y mcp-shell` to your config manually.
 
 Start (or restart) [Claude Desktop](https://claude.ai/download) and you should see the MCP tool listed on the landing page.
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,13 +19,13 @@ function getConfigPath() {
   }
 }
 
-export function updateConfig() {
+export function updateConfig(debug = false) {
   const isNpx = Boolean(
     process.argv[1].includes('/_npx/') ||
       process.env.npm_command === 'exec' ||
       process.env._?.includes('/_npx/'),
   );
-  if (!isNpx) {
+  if (!isNpx && !debug) {
     console.error({"error": 'Not running via npx'});
     return;
   }
@@ -50,7 +50,8 @@ export function updateConfig() {
       }
     } else {
       config.mcpServers['shell-server'] = {
-        command: scriptPath,
+        command: `${debug ? 'node' : 'npx'}`,
+        args: debug ? [scriptPath] : ['mcp-shell']
       };
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -150,8 +150,15 @@ class ShellServer {
 }
 
 async function main() {
+  // Get command line arguments
+  const args = process.argv.slice(2);
+  console.log(args.join(' '));
+
   // setup in claude desktop
-  updateConfig();
+  if (args.includes('config')) {
+    const debug = args.includes('--debug');
+    updateConfig(debug);
+  }
 
   // start server
   const server = new ShellServer();


### PR DESCRIPTION
Prevents extraneous mutation. Most users seem to want to use `npx -y mcp-shell` from within Claude, so we let them. Follows how `kips` uses config.